### PR TITLE
Add webhook stripe event

### DIFF
--- a/app/code/community/District/Stripe/controllers/IndexController.php
+++ b/app/code/community/District/Stripe/controllers/IndexController.php
@@ -12,4 +12,55 @@
 
 class District_Stripe_IndexController extends Mage_Core_Controller_Front_Action
 {
+    /**
+     * Receive a webhook
+     */
+    public function webhookAction()
+    {
+        // Set Stripe Api Key
+        Mage::helper('stripe')->setApiKey();
+
+        // Retrieve the payload
+        $payload = $this->getRequest()->getRawBody();
+        $sig_header = $_SERVER['HTTP_STRIPE_SIGNATURE'];
+        $event = null;
+
+        try {
+            $event = \Stripe\Webhook::constructEvent(
+                $payload, $sig_header, Mage::getStoreConfig('payment/stripe_cc/webhook_signing_secret')
+            );
+        } catch (\UnexpectedValueException $e) {
+            $this->_stop('404 Not Found');
+            return;
+        } catch (\Stripe\Error\SignatureVerification $e) {
+            $this->_stop('404 Not Found');
+            return;
+        }
+        $response = $this->getResponse();
+
+        try {
+            Mage::dispatchEvent('stripe_webhook_received_' . str_replace('.', '_', $event['type']), [
+                'payload' => $event,
+                'request' => $this->getRequest(),
+                'response' => $response,
+            ]);
+        } catch (Exception $e) {
+            $response
+                ->setHttpResponseCode(400)
+                ->appendBody($e->getMessage());
+        }
+    }
+
+    /**
+     * @param string $httpCode
+     * @param null|string $x Details
+     */
+    protected function _stop($httpCode, $x = null)
+    {
+        header(sprintf('HTTP/1.1 %s', $httpCode));
+        if (null !== $x) {
+            header(sprintf('X-Details: %s', $x));
+        }
+        exit;
+    }
 }

--- a/app/code/community/District/Stripe/etc/config.xml
+++ b/app/code/community/District/Stripe/etc/config.xml
@@ -96,6 +96,7 @@
                 <title>Stripe</title>
                 <api_secret_key backend_model="adminhtml/system_config_backend_encrypted" />
                 <api_publishable_key backend_model="adminhtml/system_config_backend_encrypted" />
+                <webhook_signing_secret backend_model="adminhtml/system_config_backend_encrypted" />
                 <payment_action>authorize_capture</payment_action>
                 <cctype>AE,MC,VI</cctype>
                 <save_cc_enabled>0</save_cc_enabled>

--- a/app/code/community/District/Stripe/etc/system.xml
+++ b/app/code/community/District/Stripe/etc/system.xml
@@ -57,6 +57,15 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
                         </api_publishable_key>
+                        <webhook_signing_secret translate="label">
+                            <label>Webhook Signing secret</label>
+                            <frontend_type>obscure</frontend_type>
+                            <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
+                            <sort_order>45</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </webhook_signing_secret>
                         <allowspecific translate="label">
                             <label>Payment from applicable countries</label>
                             <frontend_type>allowspecific</frontend_type>


### PR DESCRIPTION
Issue: Add webhook url to dispatch event data with stripe type

Add webhook url: `{{base_url}}/stripe/index/webhook`

Dispatch event `stripe_webhook_received_{stripe_event_type}`

Add `webhook_signing_secret` config to check stripe signature

Signature check doc: https://stripe.com/docs/webhooks/signatures
Webhook doc: https://stripe.com/docs/billing/webhooks


